### PR TITLE
Check for size of preserved region fixed to reflect 1 AA instead of 2

### DIFF
--- a/evo_prot_grad/common/sampler.py
+++ b/evo_prot_grad/common/sampler.py
@@ -68,7 +68,7 @@ class DirectedEvolution:
             utils.set_seed(random_seed)
         if self.preserved_regions is not None:
             for start, end in self.preserved_regions:
-                if end - start < 1:
+                if end - start < 0:
                     raise ValueError("Preserved regions must be at least 1 amino acid long")
                 
         # maintains a tokenizer with canonical alphabet


### PR DESCRIPTION
Line 71 asserts that the difference in start to end is greater than 1, but line 187, which applies the mask at sample time, apples end inclusively. Thus if the user wants to preserve a single amino acid at `pos`, they would need to pass `[ pos, pos]` which is caught by the assert.

Changed the check to be `< 0` to allow for single amino acid preserved regions.